### PR TITLE
Set fallback for notify_reply to getEmail()

### DIFF
--- a/classes/Form.php
+++ b/classes/Form.php
@@ -432,7 +432,7 @@ static function translate($key, $default, $replace = [], $fallback = NULL) {
      *
      * @return string
      */
-    private function getEmail() {
+    private function getEmail($forReplyTo = false) {
 
         $email_field = option('microman.formblock.email_field', 'email');
 
@@ -442,11 +442,11 @@ static function translate($key, $default, $replace = [], $fallback = NULL) {
 
         $emails = $this->fields()->filter('inputtype', 'email');
         
-        if ($emails->count() === 0) {
+        if ($emails->count() === 0 && !$forReplyTo) {
             throw new Exception("You need at least one field that is use for an email.");
         }
 
-        return $emails->first()->value();
+        return $emails->first()->value() ?? "";
 
     }
 
@@ -529,7 +529,7 @@ static function translate($key, $default, $replace = [], $fallback = NULL) {
             ];
 
 
-            $reply = $this->message('notify_reply', [], "");
+            $reply = $this->message('notify_reply', [], $this->getEmail($forReplyTo = true));
 
             if (!empty($reply)) {
                 $emailData['replyTo'] = $reply;


### PR DESCRIPTION
This sets the fallback for `notify_reply` (the reply-to address) to the existing `getEmail()` method that seeks out email fields automatically.

This means there is no need to manually specify `notify_reply`, and also allows for an email field to be optional while still using it for the "reply to" address if it gets filled in.

The `getEmail()` method throws an exception if no email field is found. This PR allows that exception to be bypassed if the method is being called to find an "reply to" address, so that if no email is found, then the "reply to" header just doesn't get added.