### PR TITLE
Enhancement: Ability to prefill fields from query string

### DIFF
--- a/classes/FormField.php
+++ b/classes/FormField.php
@@ -160,6 +160,12 @@ class FormField extends Block
             return implode(', ', array_map(fn($f) => f::safeName($f['name']), $this->files));
         }
 
+        // Prefill value from query string variable matching slug
+        $slug = (string) $this->content()->slug();
+        if(isset($_GET[$slug]) && ($value = $_GET[$slug])){
+            return Escape::html($value);
+        }
+
         return $raw ? $this->content()->value() : Escape::html($this->content()->value());
     }
 


### PR DESCRIPTION
This PR allows prefilling form fields from the page's query string.

For example, if you have a contact us button on a particular service page, you could prefill the service name into the form by linking to the form as so:
`https://example.com/contact-us?service=Bananas`

Or if linking to a form from a bulk email, you could pre-fill the person's name and email address:
`https://example.com/contact-us?name=Joe Bloggs&email=joe@example.com`