### PR TITLE
Add ability to add BCC fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,10 @@ notify_reply:
     enable_notify: true
 ```
 
-Same works for confirm. 
+Same works for BCC and the confirmation email:
+- `notify_bcc`
+- `confirm_reply`
+- `confirm_bcc`
 
 To disable confirmation or notification use [the config](#disable-functions).
 

--- a/classes/Form.php
+++ b/classes/Form.php
@@ -528,11 +528,14 @@ static function translate($key, $default, $replace = [], $fallback = NULL) {
                 'attachments' => $this->attachments
             ];
 
-
             $reply = $this->message('notify_reply', [], $this->getEmail($forReplyTo = true));
-
             if (!empty($reply)) {
                 $emailData['replyTo'] = $reply;
+            }
+
+            $bcc = $this->message('notify_bcc', [], "");
+            if (!empty($bcc)) {
+                $emailData['bcc'] = $bcc;
             }
 
             if (option('microman.formblock.disable_html') === false) {
@@ -591,9 +594,13 @@ static function translate($key, $default, $replace = [], $fallback = NULL) {
             }
 
             $reply = $this->message('confirm_reply', [], "");
-
             if (!empty($reply)) {
                 $emailData['replyTo'] = $reply;
+            }
+
+            $bcc = $this->message('confirm_bcc', [], "");
+            if (!empty($bcc)) {
+                $emailData['bcc'] = $bcc;
             }
 
             site()->kirby()->email($emailData);


### PR DESCRIPTION
Adds support for `notify_bcc` and `confirm_bcc` so that fields to add a BCC address can be added to the blueprint if required.