### PR TITLE
fix: merge custom and default notify and confirm configs

### DIFF
--- a/classes/FormBlueprint.php
+++ b/classes/FormBlueprint.php
@@ -119,8 +119,8 @@ class FormBlueprint
                     ],
                     'info' => static::getInfoText()
                 ],
-                (static::isEnabled('notify')) ?  Yaml::read(__DIR__ . "/../blueprints/snippets/form_notify.yml") : [],
-                (static::isEnabled('confirm')) ?  Yaml::read(__DIR__ . "/../blueprints/snippets/form_confirm.yml") : [],
+                (static::isEnabled('notify')) ? static::getBlueprint('snippets/form_notify') : [],
+                (static::isEnabled('confirm')) ? static::getBlueprint('snippets/form_confirm') : [],
                 static::getBlueprint('snippets/form_options')
             )
         ];


### PR DESCRIPTION
In the readme, you say: "You can do the same with form_confirm.yml and form_notify.yml.".
But the configs for this 2 files is never read from the site/blueprints folder.
This will allow to do just that.