### PR TITLE
Feature: form message storage toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,16 @@ For a clear overview, name your form blocks.
 
 > ☝️ Be carefull! Deleting form blocks will also deleting all requests of this form block without promting!
 
+## Message storage toggle
+
+For privacy reasons, the storage of form submissions can be disabled per form. A toggle is available in the inbox toolbar next to the "Delete all" and "Export CSV" buttons.
+
+- **Enabled (default):** Submissions are stored as usual and can be viewed in the inbox.
+- **Disabled:** The form works identically (notification and confirmation emails are still sent, including attachments), but no submissions are stored in the panel.
+
+When storage is disabled, the block overview displays an info message instead of the request counter.
+
+> The toggle state is persisted per form. Disabling storage does not delete existing submissions.
 
 # Advanced customizing
 

--- a/classes/Form.php
+++ b/classes/Form.php
@@ -740,36 +740,40 @@ static function translate($key, $default, $replace = [], $fallback = null) {
                 'allowCreate'   => true
             ]);    
 
-            $request = $this->request->create( [
-                'received' => date('Y-m-d H:i:s', time()),
-                'formdata' => json_encode($this->fieldsWithPlaceholder()),
-                'formfields' => json_encode($this->fieldsWithPlaceholder('label')),
-                'read' => "",
-                'display' => $this->message('display')
-            ], $this->hash());
+            $storageEnabled = $this->request->isStorageEnabled();
 
-            //Reqeust not already exists
-            if(!is_null($request)) {
+            if ($storageEnabled) {
+                $request = $this->request->create( [
+                    'received' => date('Y-m-d H:i:s', time()),
+                    'formdata' => json_encode($this->fieldsWithPlaceholder()),
+                    'formfields' => json_encode($this->fieldsWithPlaceholder('label')),
+                    'read' => "",
+                    'display' => $this->message('display')
+                ], $this->hash());
 
-                $this->attachments = $this->request->uploadFiles($this->attachmentFields());
-                
-                // Send notification mail
-                if (!option('plain.formblock.disable_notify') && !$this->isFatal() && $this->enable_notify()->isTrue()) {
-                    $this->sendNotification();
+                //Reqeust not already exists
+                if(is_null($request)) {
+                    return;
                 }
-                
-                // Send confirmation mail
-                if (!option('plain.formblock.disable_confirmation') && !$this->isFatal() && $this->enable_confirm()->isTrue()) {
-                    $this->sendConfirmation();
-                }
-                
-                $this->hash('true');
-
-                kirby()->trigger('formblock.success:after', [
-                    'request' => $this->request,
-                ]);
-
             }
+
+            $this->attachments = $this->request->uploadFiles($this->attachmentFields());
+                
+            // Send notification mail
+            if (!option('plain.formblock.disable_notify') && !$this->isFatal() && $this->enable_notify()->isTrue()) {
+                $this->sendNotification();
+            }
+            
+            // Send confirmation mail
+            if (!option('plain.formblock.disable_confirmation') && !$this->isFatal() && $this->enable_confirm()->isTrue()) {
+                $this->sendConfirmation();
+            }
+            
+            $this->hash('true');
+
+            kirby()->trigger('formblock.success:after', [
+                'request' => $this->request,
+            ]);
 
         }
     }

--- a/classes/Request.php
+++ b/classes/Request.php
@@ -30,6 +30,8 @@ class Request
 
     protected $page_id;
 
+    protected $form_id;
+
     /**
      * Request container
      *
@@ -62,6 +64,7 @@ class Request
     {
         
         $this->page_id = $props['page_id'] ?? 'site';
+        $this->form_id = $props['form_id'] ?? null;
 
         //Get Page
         if ($this->page_id === 'site') {
@@ -232,6 +235,43 @@ class Request
     }
 
     /**
+     * Set storage enabled/disabled for this form
+     *
+     * @param array $params
+     * @return array
+     */
+    public function setStorageEnabled($params = [])
+    {
+        if (is_null($this->container) && $this->form_id) {
+            $this->createContainer([
+                'form_id' => $this->form_id,
+                'form_name' => $this->form_id,
+            ]);
+        }
+        if (is_null($this->container)) {
+            return ['enabled' => true];
+        }
+        $enabled = $params['enabled'] ?? true;
+        $this->updateContainer([
+            'storage_enabled' => $enabled ? 'true' : 'false'
+        ]);
+        return ['enabled' => $enabled];
+    }
+
+    /**
+     * Check if storage is enabled for a container
+     *
+     * @param \Kirby\Cms\Page|null $container
+     * @return bool
+     */
+    public function isStorageEnabled($container = null): bool
+    {
+        $container ??= $this->container;
+        if (is_null($container)) return true;
+        return $container->content()->storage_enabled()->value() !== 'false';
+    }
+
+    /**
      * Update container
      *
      * @param array $input Changes
@@ -275,7 +315,9 @@ class Request
             $this->verifyName($params['form_name']);
         }
 
-        return $this->infoPart('array');
+        $result = $this->infoPart('array');
+        $result['storageEnabled'] = $this->isStorageEnabled();
+        return $result;
 
 
     }
@@ -445,12 +487,12 @@ class Request
     public function requestsArray($props = []) {
         
         $out = array();
+        $filter = $props['filter'] ?? [];
 
         foreach ($this->forms as $a) {
 
             $content = [];
             $read = 0;
-            $filter = $props['filter'];
 
             if (count($filter) > 0 && in_array($a->slug(), $filter) === false) {
                 continue;
@@ -470,6 +512,7 @@ class Request
                 "id" => $a->slug(),
                 "page" => $this->page_id,
                 "uuid" => $a->content()->uuid()->value(),
+                "storageEnabled" => $this->isStorageEnabled($a),
                 "header" => [
                     "page" => $pagetitle,
                     "name" => $formtitle,
@@ -478,6 +521,35 @@ class Request
                 ]
             ] ;
             
+        }
+
+        // Add placeholder entries for filtered forms that have no container yet
+        foreach ($filter as $form_id) {
+            if (!isset($out[$form_id])) {
+                $pagetitle = ($this->page && $this->page->title()) ? $this->page->title()->value() : site()->title()->value();
+                $formtitle = $pagetitle . " - " . $form_id;
+
+                // Check if container exists as draft (without being in forms index)
+                $existingContainer = $this->page->childrenAndDrafts()->findBy('slug', $form_id);
+                $storageEnabled = true;
+                if ($existingContainer && $existingContainer->content()->storage_enabled()->value() === 'false') {
+                    $storageEnabled = false;
+                }
+
+                $out[$form_id] = [
+                    "content" => [],
+                    "id" => $form_id,
+                    "page" => $this->page_id,
+                    "uuid" => $existingContainer ? $existingContainer->content()->uuid()->value() : "",
+                    "storageEnabled" => $storageEnabled,
+                    "header" => [
+                        "page" => $pagetitle,
+                        "name" => $formtitle,
+                        "state" => $this->infoPart('array', $existingContainer),
+                        "download" => ""
+                    ]
+                ];
+            }
         }
 
         return $out;
@@ -544,24 +616,26 @@ class Request
                 //Push File for email upload
                 array_push($attachments, $filename);
 
-                //Save file
-                $localfile = $this->request->createFile([
-                    'source'     => $filename,
-                    'template'   => 'formfile',
-                    'filename'   => $name,
-                    'content'   => [
-                        'filename'   =>  $f['name'],
-                        'field'      => $field_slug
-                    ]
-                ]);
+                //Save file to request page (only if storage is enabled)
+                if (!is_null($this->request)) {
+                    $localfile = $this->request->createFile([
+                        'source'     => $filename,
+                        'template'   => 'formfile',
+                        'filename'   => $name,
+                        'content'   => [
+                            'filename'   =>  $f['name'],
+                            'field'      => $field_slug
+                        ]
+                    ]);
 
-                //Push fileinfos
-                array_push($filearray, [
-                    'name' => F::safeName($f['name']),
-                    'tmp_name' => $name,
-                    'location' => $localfile->url(),
-                    'size' => $f['size']
-                ]);
+                    //Push fileinfos
+                    array_push($filearray, [
+                        'name' => F::safeName($f['name']),
+                        'tmp_name' => $name,
+                        'location' => $localfile->url(),
+                        'size' => $f['size']
+                    ]);
+                }
 
             }
 
@@ -570,7 +644,9 @@ class Request
             
         }
 
-        $this->update(['attachment' => json_encode($fileinfos)]);
+        if (!is_null($this->request)) {
+            $this->update(['attachment' => json_encode($fileinfos)]);
+        }
 
         return $attachments;
         

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -138,5 +138,7 @@
   "form.block.fromfields.captcha.fail": "Meldung bei falscher Eingabe",
   "form.block.fromfields.captcha.ask": "Aufgabendefinition",
   "form.block.options.notify_placeholder": "Name <mail@domain.ch>",
-  "form.block.inbox.export": "CSV exportieren"
+  "form.block.inbox.export": "CSV exportieren",
+  "form.block.inbox.storage": "Nachrichten speichern",
+  "form.block.inbox.storage.disabled": "Speicherung der Nachrichten deaktiviert"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -15,6 +15,8 @@
   "form.block.inbox.tooltip.unread": "This request has not been read yet",
   "form.block.inbox.notinblock": "The mail view field can only be used in form blocks",
   "form.block.inbox.export": "Export CSV",
+  "form.block.inbox.storage": "Save messages",
+  "form.block.inbox.storage.disabled": "Message storage disabled",
   "form.block.migrate.success": "Your form data has just been migrated. Please save the page to continue working.",
   "form.block.fromfields": "Form fields",
   "form.block.fromfields.label": "Display name",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -139,6 +139,8 @@
   "form.block.fromfields.captcha.ask": "Définition de la tâche",
   "form.block.options.notify_placeholder": "Nom <mail@domain.ch>",
   "form.block.inbox.export": "Exporter CSV",
+  "form.block.inbox.storage": "Sauvegarder les messages",
+  "form.block.inbox.storage.disabled": "Stockage des messages d\u00e9sactiv\u00e9",
   "marektplace.api.error": "La demande a échoué, veuillez contacter l'assistance.",
   "marketplace.domain.text.domain": "Votre licence sera activée pour le domaine <strong>{host}</strong>.",
   "marketplace.login.headline.help": "{{additional}}Si vous utilisez la Marketplace pour la première fois, vous devez d'abord <a href=\"{{buy}}\" targe=\"_blank\">acheter une licence</a>.",

--- a/i18n/hu.json
+++ b/i18n/hu.json
@@ -139,6 +139,8 @@
   "form.block.fromfields.captcha.ask": "Feladat meghatározása",
   "form.block.options.notify_placeholder": "Név <mail@domain.ch>",
   "form.block.inbox.export": "CSV exportálása",
+  "form.block.inbox.storage": "Üzenetek mentése",
+  "form.block.inbox.storage.disabled": "Üzenetek tárolása letiltva",
   "marektplace.api.error": "A kérés sikertelen, kérjük, lépjen kapcsolatba az ügyfélszolgálattal.",
   "marketplace.domain.text.domain": "A licenc a <strong>{host}</strong> domainre lesz aktiválva.",
   "marketplace.login.headline.help": "{{additional}}}Ha először használja a Piacteret, először <a href=\"{{buy}}\" targe=\"_blank\">meg kell vásárolnia egy licencet</a>.",

--- a/i18n/lt.json
+++ b/i18n/lt.json
@@ -139,6 +139,8 @@
   "form.block.fromfields.captcha.ask": "Užduoties apibrėžimas",
   "form.block.options.notify_placeholder": "Vardas <mail@domain.ch>",
   "form.block.inbox.export": "CSV eksportas",
+  "form.block.inbox.storage": "Išsaugoti žinutes",
+  "form.block.inbox.storage.disabled": "Žinučių saugojimas išjungtas",
   "marektplace.api.error": "Užklausa nepavyko, kreipkitės į palaikymo komandą.",
   "marketplace.domain.text.domain": "Jūsų licencija bus aktyvuota domenui <strong>{host}</strong>.",
   "marketplace.login.headline.help": "{{additional}}Jei \"Marketplace\" naudojatės pirmą kartą, pirmiausia turite <a href=\"{{{buy}}\" targe=\"_blank\">įsigyti bet kokią licenciją</a>.",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -139,6 +139,8 @@
   "form.block.license.error.test": "De licentietool is momenteel in testmodus. Probeer het later opnieuw.",
   "form.block.fromfields.captcha.info": "Gebruik slechts één keer per formulier!",
   "form.block.inbox.export": "CSV exporteren",
+  "form.block.inbox.storage": "Berichten opslaan",
+  "form.block.inbox.storage.disabled": "Berichtopslag uitgeschakeld",
   "marektplace.api.error": "Het verzoek is mislukt, neem contact op met ondersteuning.",
   "marketplace.domain.text.domain": "Je licentie wordt geactiveerd voor het domein <strong>{host}</strong>.",
   "marketplace.login.headline.help": "{{additional}}Als u de Marktplaats voor het eerst gebruikt, moet u eerst <a href=\"{{buy}}\" targe=\"_blank\">een licentie kopen</a>.",

--- a/index.css
+++ b/index.css
@@ -30,20 +30,34 @@
   box-shadow: none;
   border-radius: 0;
 }
+.k-mailview-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-3);
+}
 .k-mailview-buttons {
   display: flex;
-  justify-content: end;
+  align-items: center;
+}
+.k-mailview-storage-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+.k-mailview-storage-label {
+  font-size: var(--text-sm);
+  white-space: nowrap;
 }
 .k-mailview-list-header {
   position: relative;
 }
-.k-mailview-list-header>.k-button {
+.k-mailview-list-header > .k-button {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
   right: var(--spacing-1);
 }
-
 .k-plain-license {
   cursor: pointer;
   display: flex;

--- a/index.js
+++ b/index.js
@@ -1,457 +1,769 @@
-(function() {
+(function () {
   "use strict";
-  function normalizeComponent(scriptExports, render, staticRenderFns, functionalTemplate, injectStyles, scopeId, moduleIdentifier, shadowMode) {
-    var options = typeof scriptExports === "function" ? scriptExports.options : scriptExports;
-    if (render) {
-      options.render = render;
-      options.staticRenderFns = staticRenderFns;
-      options._compiled = true;
-    }
-    return {
-      exports: scriptExports,
-      options
-    };
-  }
-  const _sfc_main$4 = {
-    data() {
-      return {
-        migrate: false,
-        loading: true,
-        status: {
-          type: Object,
-          default: {
-            count: "-",
-            read: "-",
-            fail: "-",
-            state: "wait"
-          }
-        }
-      };
+  var g = function () {
+      var t = this,
+        e = t.$createElement,
+        n = t._self._c || e;
+      return n(
+        "div",
+        [
+          n(
+            "k-grid",
+            { staticStyle: { gap: "0.25rem", "--columns": "12" } },
+            [
+              n(
+                "k-input",
+                t._b(
+                  {
+                    staticStyle: { "--width": "1/3" },
+                    attrs: { type: "text" },
+                    on: { input: t.onInput },
+                    model: {
+                      value: t.content.name,
+                      callback: function (i) {
+                        t.$set(t.content, "name", i);
+                      },
+                      expression: "content.name",
+                    },
+                  },
+                  "k-input",
+                  t.field("name"),
+                  !1
+                )
+              ),
+              t.loading
+                ? n("k-box", {
+                    staticStyle: { "--width": "2/3" },
+                    attrs: {
+                      theme: "info",
+                      icon: "loader",
+                      text: t.$t("form.block.inbox.loading"),
+                    },
+                  })
+                : t.status.storageEnabled
+                ? n("k-box", {
+                    staticStyle: { "--width": "2/3" },
+                    attrs: {
+                      icon: "email",
+                      theme: t.status.theme,
+                      text:
+                        t.$t("form.block.inbox.show") +
+                        " (" +
+                        t.status.text +
+                        ")",
+                    },
+                    nativeOn: {
+                      click: function (i) {
+                        return t.open.apply(null, arguments);
+                      },
+                    },
+                  })
+                : n("k-box", {
+                    staticStyle: { "--width": "2/3" },
+                    attrs: {
+                      icon: "cancel",
+                      theme: "info",
+                      text: t.$t("form.block.inbox.storage.disabled"),
+                    },
+                    nativeOn: {
+                      click: function (i) {
+                        return t.open.apply(null, arguments);
+                      },
+                    },
+                  }),
+            ],
+            1
+          ),
+        ],
+        1
+      );
     },
-    destroyed() {
-      window.panel.events.off("form.update", this.updateCount);
-    },
-    created() {
-      window.panel.events.on("content/STATUS", function(mutation) {
-        if (mutation.type == "content/STATUS")
-          window.panel.events.emit("form.update");
-      });
-      this.content.formid = this.id;
-      this.updateCount();
-      window.panel.events.on("form.update", this.updateCount);
-    },
-    methods: {
-      updateCount() {
-        const $this = this;
-        this.$api.get("formblock", {
-          action: "info",
-          form_id: this.id,
-          params: JSON.stringify({ form_name: this.content.name })
-        }).then((data) => {
-          $this.status = data;
-          this.loading = false;
-        });
-      },
-      onInput(value) {
-        this.$emit("update", value);
-      }
-    }
-  };
-  var _sfc_render$4 = function render() {
-    var _vm = this, _c = _vm._self._c;
-    return _c("div", [_c("k-grid", { staticStyle: { "gap": "0.25rem", "--columns": "12" } }, [_c("k-input", _vm._b({ staticStyle: { "--width": "1/3" }, attrs: { "type": "text" }, on: { "input": _vm.onInput }, model: { value: _vm.content.name, callback: function($$v) {
-      _vm.$set(_vm.content, "name", $$v);
-    }, expression: "content.name" } }, "k-input", _vm.field("name"), false)), _vm.loading ? _c("k-box", { staticStyle: { "--width": "2/3" }, attrs: { "theme": "info", "icon": "loader", "text": _vm.$t("form.block.inbox.loading") } }) : _c("k-box", { staticStyle: { "--width": "2/3" }, attrs: { "icon": "email", "theme": _vm.status.theme, "text": _vm.$t("form.block.inbox.show") + " (" + _vm.status.text + ")" }, nativeOn: { "click": function($event) {
-      return _vm.open.apply(null, arguments);
-    } } })], 1)], 1);
-  };
-  var _sfc_staticRenderFns$4 = [];
-  _sfc_render$4._withStripped = true;
-  var __component__$4 = /* @__PURE__ */ normalizeComponent(
-    _sfc_main$4,
-    _sfc_render$4,
-    _sfc_staticRenderFns$4
-  );
-  __component__$4.options.__file = "/Users/romangsponer/Cloud/_kirby/kdev/site/plugins/kirby-form-block-suite/src/components/blocks/Form.vue";
-  const Form = __component__$4.exports;
-  const _sfc_main$3 = {
-    extends: "k-dialog",
-    props: {
-      current: {
-        type: Object,
-        default() {
-        }
-      }
-    }
-  };
-  var _sfc_render$3 = function render() {
-    var _vm = this, _c = _vm._self._c;
-    return _c("k-dialog", _vm._b({ ref: "dialog", staticClass: "k-field-type-page-dialog", on: { "cancel": function($event) {
-      return _vm.$emit("cancel");
-    }, "submit": function($event) {
-      return _vm.$emit("submit");
-    } } }, "k-dialog", _vm.$props, false), [_c("k-headline", [_vm._v(_vm._s(_vm.current.title))]), _vm.current.formfields ? _c("div", [_c("table", { staticClass: "k-field-type-page-dialog-table" }, _vm._l(_vm.current.formfields, function(label, key) {
-      return _c("tr", { key, class: "field_" + key }, [_c("td", [_vm._v(_vm._s(label))]), _vm.current.attachment[key] ? _c("td", [_c("ul", { staticClass: "k-field-type-page-dialog-linklist" }, _vm._l(_vm.current.attachment[key], function(f) {
-        return _c("li", { key: f.tmp_name }, [_c("a", { staticClass: "k-field-type-page-dialog-link", attrs: { "href": f.location, "download": f.name } }, [_c("k-icon", { attrs: { "type": "attachment" } }), _vm._v(" " + _vm._s(f.name) + " ")], 1)]);
-      }), 0)]) : _c("td", [_vm._v(" " + _vm._s(_vm.current.formdata[key]) + " ")])]);
-    }), 0)]) : _c("div", { staticClass: "k-field-type-page-dialog-table" }, [_vm._v(" " + _vm._s(_vm.current.formdata.summary) + " ")]), _vm.current.error ? _c("k-box", { attrs: { "text": _vm.current.error, "theme": "negative" } }) : _vm._e()], 1);
-  };
-  var _sfc_staticRenderFns$3 = [];
-  _sfc_render$3._withStripped = true;
-  var __component__$3 = /* @__PURE__ */ normalizeComponent(
-    _sfc_main$3,
-    _sfc_render$3,
-    _sfc_staticRenderFns$3
-  );
-  __component__$3.options.__file = "/Users/romangsponer/Cloud/_kirby/kdev/site/plugins/kirby-form-block-suite/src/components/dialog/Form.vue";
-  const MailDialog = __component__$3.exports;
-  const _sfc_main$2 = {
-    props: {
-      value: {
-        type: Array,
-        required: true
-      },
-      showuuid: Boolean,
-      hideheader: Boolean
-    },
-    data() {
-      return {
-        isOpen: false
-      };
-    },
-    computed: {
-      items() {
-        const a = this.value.content;
-        if (a.length === 0) {
-          return [
-            {
-              text: this.$t("form.block.inbox.empty"),
-              theme: "disabled"
-            }
-          ];
-        }
-        return this.value.content;
-      },
-      headerText() {
-        if (this.showuuid) {
-          return this.value.header.name + " (" + this.value.uuid + ")";
-        }
-        return this.value.header.name;
-      }
-    },
-    created() {
-      this.isOpen = sessionStorage.getItem(
-        `plain.form.showOpen.${this.value.page}.${this.value.uuid}`
-      ) === "on";
-    },
-    methods: {
-      toggleOpen() {
-        this.isOpen = !this.isOpen;
-        sessionStorage.setItem(
-          `plain.form.showOpen.${this.value.page}.${this.value.uuid}`,
-          this.isOpen ? "on" : "off"
-        );
-      },
-      onDelete() {
-        this.$panel.dialog.open({
-          component: "k-remove-dialog",
-          props: {
-            text: this.$t("field.entries.delete.confirm.all")
-          },
-          on: {
-            submit: () => {
-              this.$api.get("formblock", {
-                action: "deleteAll",
-                page_id: this.value.page,
-                form_id: this.value.id
-              }).then((data) => {
-                this.$emit("refresh");
-                this.$panel.dialog.close();
-              });
-            }
-          }
-        });
-      }
-    }
-  };
-  var _sfc_render$2 = function render() {
-    var _vm = this, _c = _vm._self._c;
-    return _c("div", { staticClass: "k-mailview-list" }, [!_vm.hideheader ? _c("div", { staticClass: "k-mailview-list-header" }, [_c("k-box", { attrs: { "theme": _vm.value.header.state.theme, "icon": _vm.isOpen ? "angle-up" : "angle-down", "text": _vm.headerText }, nativeOn: { "click": function($event) {
-      return _vm.toggleOpen();
-    } } }), _c("k-button", { attrs: { "icon": "download", "variant": "filled", "link": _vm.value.header.download, "theme": _vm.value.header.state.theme, "download": true } })], 1) : _c("k-button-group", { staticClass: "k-mailview-buttons" }, [_c("k-button", { attrs: { "icon": "cancel", "theme": "red", "text": _vm.$t("delete.all") }, on: { "click": _vm.onDelete } }), _c("k-button", { attrs: { "icon": "download", "link": _vm.value.header.download, "text": _vm.$t("form.block.inbox.export"), "download": true } })], 1), _vm.isOpen || _vm.hideheader ? _c("k-items", { attrs: { "items": _vm.items } }) : _vm._e()], 1);
-  };
-  var _sfc_staticRenderFns$2 = [];
-  _sfc_render$2._withStripped = true;
-  var __component__$2 = /* @__PURE__ */ normalizeComponent(
-    _sfc_main$2,
-    _sfc_render$2,
-    _sfc_staticRenderFns$2
-  );
-  __component__$2.options.__file = "/Users/romangsponer/Cloud/_kirby/kdev/site/plugins/kirby-form-block-suite/src/components/MailList.vue";
-  const MailList = __component__$2.exports;
-  const _sfc_main$1 = {
-    props: {
-      value: {
-        type: String,
-        default: ""
-      },
-      dateformat: {
-        type: String,
-        default: "DD.MM.YYYY HH:mm"
-      },
-      forms: {
-        type: Array,
-        default: () => []
-      },
-      formData: {
-        type: Object,
-        default: () => {
-        }
-      }
-    },
-    data() {
-      return {
-        data: [],
-        filter: [],
-        loading: true,
-        hideheader: false
-      };
-    },
-    computed: {
-      thispage() {
-        return this.$attrs.endpoints.model.replace("/pages/", "").replace(/\+/g, "/");
-      }
-    },
-    created() {
-      if (this.formData.formid) {
-        this.filter = [this.formData.formid];
-        this.hideheader = true;
-      } else {
-        this.filter = this.forms;
-      }
-      this.updateList();
-      window.panel.events.on("form.update", this.updateList);
-    },
-    destroyed() {
-      window.panel.events.off("form.update", this.updateList);
-    },
-    methods: {
-      send(action, params, callback) {
-        this.$api.get("formblock", {
-          action,
-          page_id: this.thispage,
-          request_id: (params == null ? void 0 : params.request) ?? "",
-          form_id: (params == null ? void 0 : params.form) ?? "",
-          params: JSON.stringify(params)
-        }).then((data) => {
-          this.loading = false;
-          callback(data);
-        });
-      },
-      isUnique(a) {
-        return this.data.filter((b) => {
-          return a.header.page === b.header.page && a.header.name === b.header.name;
-        }).length > 1;
-      },
-      updateList() {
-        let $this = this;
-        this.send("requestsArray", { filter: this.filter }, (data) => {
-          this.data = Object.keys(data).map(function(key) {
-            data[key].content = data[key].content.map((req) => {
-              req.formid = key;
-              req.attachment = "attachment" in req ? JSON.parse(req.attachment) : false;
-              req.formdata = JSON.parse(req.formdata);
-              req.formfields = "formfields" in req ? JSON.parse(req.formfields) : false;
-              let thisDate = $this.$library.dayjs(
-                req.received,
-                "YYYY-MM-DD HH:mm:ss"
-              );
-              req.info = thisDate.isValid() ? thisDate.format($this.dateformat) : "";
-              req.text = $this.getLabel(req);
-              req.image = $this.getImage(req);
-              req.buttons = [$this.getButton("info", req)];
-              req.options = [
-                req.read === "" ? $this.getButton("unread", req) : $this.getButton("read", req),
-                $this.getButton("delete", req)
-              ];
-              return req;
-            });
-            return data[key];
-          });
-        });
-      },
-      setRead(state, item) {
-        this.send(
-          "update",
-          {
-            form: item.formid,
-            request: item.slug,
-            read: state == false ? "" : this.$library.dayjs().format("YYYY-MM-DD HH:mm:ss")
-          },
-          () => {
-            window.panel.events.emit("form.update");
-            this.$panel.dialog.close();
-          }
-        );
-      },
-      getLabel(req) {
-        if (req.display) return req.display;
-        if (!this.value) return req.id;
-        return this.$helper.string.template(this.value, req.formdata);
-      },
-      getButton(type, item) {
-        if (type === "delete") {
-          return {
-            icon: "trash",
-            text: this.$t("form.block.inbox.delete"),
-            click: () => this.send(
-              "delete",
-              {
-                form: item.formid,
-                request: item.slug
-              },
-              () => {
-                window.panel.events.emit("form.update");
+    b = [];
+  function d(t, e, n, i, a, l, m, W) {
+    var s = typeof t == "function" ? t.options : t;
+    e && ((s.render = e), (s.staticRenderFns = n), (s._compiled = !0)),
+      i && (s.functional = !0),
+      l && (s._scopeId = "data-v-" + l);
+    var r;
+    if (
+      (m
+        ? ((r = function (o) {
+            (o =
+              o ||
+              (this.$vnode && this.$vnode.ssrContext) ||
+              (this.parent &&
+                this.parent.$vnode &&
+                this.parent.$vnode.ssrContext)),
+              !o &&
+                typeof __VUE_SSR_CONTEXT__ != "undefined" &&
+                (o = __VUE_SSR_CONTEXT__),
+              a && a.call(this, o),
+              o && o._registeredComponents && o._registeredComponents.add(m);
+          }),
+          (s._ssrRegister = r))
+        : a &&
+          (r = W
+            ? function () {
+                a.call(
+                  this,
+                  (s.functional ? this.parent : this).$root.$options.shadowRoot
+                );
               }
-            )
-          };
-        }
-        if (type === "unread") {
-          return {
-            icon: "preview",
-            text: this.$t("form.block.inbox.asread"),
-            click: () => this.setRead(true, item)
-          };
-        }
-        if (type === "read") {
-          return {
-            icon: "hidden",
-            text: this.$t("form.block.inbox.asunread"),
-            click: () => this.setRead(false, item)
-          };
-        }
+            : a),
+      r)
+    )
+      if (s.functional) {
+        s._injectStyles = r;
+        var G = s.render;
+        s.render = function (K, v) {
+          return r.call(v), G(K, v);
+        };
+      } else {
+        var _ = s.beforeCreate;
+        s.beforeCreate = _ ? [].concat(_, r) : [r];
+      }
+    return { exports: t, options: s };
+  }
+  const k = {
+      data() {
         return {
-          icon: "info",
-          click: () => this.$panel.dialog.open({
-            component: "k-mail-dialog",
-            props: {
-              current: item,
-              size: "medium",
-              submitButton: item.read ? {} : this.getButton("unread", item),
-              cancelButton: item.read ? this.getButton("read", item) : {}
+          migrate: !1,
+          loading: !0,
+          status: {
+            type: Object,
+            default: { count: "-", read: "-", fail: "-", state: "wait" },
+          },
+        };
+      },
+      destroyed() {
+        window.panel.events.off("form.update", this.updateCount);
+      },
+      created() {
+        window.panel.events.on("content/STATUS", function (t) {
+          t.type == "content/STATUS" && window.panel.events.emit("form.update");
+        }),
+          (this.content.formid = this.id),
+          this.updateCount(),
+          window.panel.events.on("form.update", this.updateCount);
+      },
+      methods: {
+        updateCount() {
+          const t = this;
+          this.$api
+            .get("formblock", {
+              action: "info",
+              form_id: this.id,
+              params: JSON.stringify({ form_name: this.content.name }),
+            })
+            .then((e) => {
+              (t.status = e), (this.loading = !1);
+            });
+        },
+        onInput(t) {
+          this.$emit("update", t);
+        },
+      },
+    },
+    u = {};
+  var $ = d(k, g, b, !1, y, null, null, null);
+  function y(t) {
+    for (let e in u) this[e] = u[e];
+  }
+  var w = (function () {
+      return $.exports;
+    })(),
+    x = function () {
+      var t = this,
+        e = t.$createElement,
+        n = t._self._c || e;
+      return n(
+        "k-dialog",
+        t._b(
+          {
+            ref: "dialog",
+            staticClass: "k-field-type-page-dialog",
+            on: {
+              cancel: function (i) {
+                return t.$emit("cancel");
+              },
+              submit: function (i) {
+                return t.$emit("submit");
+              },
+            },
+          },
+          "k-dialog",
+          t.$props,
+          !1
+        ),
+        [
+          n("k-headline", [t._v(t._s(t.current.title))]),
+          t.current.formfields
+            ? n("div", [
+                n(
+                  "table",
+                  { staticClass: "k-field-type-page-dialog-table" },
+                  t._l(t.current.formfields, function (i, a) {
+                    return n("tr", { key: a, class: "field_" + a }, [
+                      n("td", [t._v(t._s(i))]),
+                      t.current.attachment[a]
+                        ? n("td", [
+                            n(
+                              "ul",
+                              {
+                                staticClass:
+                                  "k-field-type-page-dialog-linklist",
+                              },
+                              t._l(t.current.attachment[a], function (l) {
+                                return n("li", { key: l.tmp_name }, [
+                                  n(
+                                    "a",
+                                    {
+                                      staticClass:
+                                        "k-field-type-page-dialog-link",
+                                      attrs: {
+                                        href: l.location,
+                                        download: l.name,
+                                      },
+                                    },
+                                    [
+                                      n("k-icon", {
+                                        attrs: { type: "attachment" },
+                                      }),
+                                      t._v(" " + t._s(l.name) + " "),
+                                    ],
+                                    1
+                                  ),
+                                ]);
+                              }),
+                              0
+                            ),
+                          ])
+                        : n("td", [
+                            t._v(" " + t._s(t.current.formdata[a]) + " "),
+                          ]),
+                    ]);
+                  }),
+                  0
+                ),
+              ])
+            : n("div", { staticClass: "k-field-type-page-dialog-table" }, [
+                t._v(" " + t._s(t.current.formdata.summary) + " "),
+              ]),
+          t.current.error
+            ? n("k-box", {
+                attrs: { text: t.current.error, theme: "negative" },
+              })
+            : t._e(),
+        ],
+        1
+      );
+    },
+    S = [],
+    Q = "";
+  const C = {
+      extends: "k-dialog",
+      props: { current: { type: Object, default() {} } },
+    },
+    c = {};
+  var O = d(C, x, S, !1, D, null, null, null);
+  function D(t) {
+    for (let e in c) this[e] = c[e];
+  }
+  var M = (function () {
+      return O.exports;
+    })(),
+    E = function () {
+      var t = this,
+        e = t.$createElement,
+        n = t._self._c || e;
+      return n(
+        "div",
+        { staticClass: "k-mailview-list" },
+        [
+          t.hideheader
+            ? n(
+                "div",
+                { staticClass: "k-mailview-toolbar" },
+                [
+                  n(
+                    "div",
+                    { staticClass: "k-mailview-storage-toggle" },
+                    [
+                      n("label", { staticClass: "k-mailview-storage-label" }, [
+                        t._v(t._s(t.$t("form.block.inbox.storage"))),
+                      ]),
+                      n("k-toggle-input", {
+                        attrs: { value: t.storageEnabled },
+                        on: { input: t.toggleStorage },
+                      }),
+                    ],
+                    1
+                  ),
+                  t.value.content.length > 0
+                    ? n(
+                        "k-button-group",
+                        { staticClass: "k-mailview-buttons" },
+                        [
+                          n("k-button", {
+                            attrs: {
+                              icon: "cancel",
+                              theme: "red",
+                              text: t.$t("delete.all"),
+                            },
+                            on: { click: t.onDelete },
+                          }),
+                          n("k-button", {
+                            attrs: {
+                              icon: "download",
+                              link: t.value.header.download,
+                              text: t.$t("form.block.inbox.export"),
+                              download: !0,
+                            },
+                          }),
+                        ],
+                        1
+                      )
+                    : t._e(),
+                ],
+                1
+              )
+            : t._e(),
+          t.hideheader
+            ? t._e()
+            : n(
+                "div",
+                { staticClass: "k-mailview-list-header" },
+                [
+                  n("k-box", {
+                    attrs: {
+                      theme: t.value.header.state.theme,
+                      icon: t.isOpen ? "angle-up" : "angle-down",
+                      text: t.headerText,
+                    },
+                    nativeOn: {
+                      click: function (i) {
+                        return t.toggleOpen();
+                      },
+                    },
+                  }),
+                  n("k-button", {
+                    attrs: {
+                      icon: "download",
+                      variant: "filled",
+                      link: t.value.header.download,
+                      theme: t.value.header.state.theme,
+                      download: !0,
+                    },
+                  }),
+                ],
+                1
+              ),
+          t.isOpen || t.hideheader
+            ? [
+                t.value.content.length === 0
+                  ? n("k-box", {
+                      attrs: {
+                        theme: "info",
+                        text: t.$t("form.block.inbox.empty"),
+                      },
+                    })
+                  : n("k-items", { attrs: { items: t.items } }),
+              ]
+            : t._e(),
+        ],
+        2
+      );
+    },
+    R = [],
+    Z = "";
+  const T = {
+      props: {
+        value: { type: Array, required: !0 },
+        showuuid: Boolean,
+        hideheader: Boolean,
+      },
+      data() {
+        return { isOpen: !1, storageEnabled: !0 };
+      },
+      computed: {
+        items() {
+          return this.value.content;
+        },
+        headerText() {
+          return this.showuuid
+            ? this.value.header.name + " (" + this.value.uuid + ")"
+            : this.value.header.name;
+        },
+      },
+      created() {
+        (this.isOpen =
+          sessionStorage.getItem(
+            `plain.form.showOpen.${this.value.page}.${this.value.uuid}`
+          ) === "on"),
+          (this.storageEnabled = this.value.storageEnabled !== !1);
+      },
+      methods: {
+        toggleOpen() {
+          (this.isOpen = !this.isOpen),
+            sessionStorage.setItem(
+              `plain.form.showOpen.${this.value.page}.${this.value.uuid}`,
+              this.isOpen ? "on" : "off"
+            );
+        },
+        toggleStorage(t) {
+          this.$api
+            .get("formblock", {
+              action: "setStorageEnabled",
+              page_id: this.value.page,
+              form_id: this.value.id,
+              params: JSON.stringify({ enabled: t }),
+            })
+            .then(() => {
+              this.storageEnabled = t;
+            });
+        },
+        onDelete() {
+          this.$panel.dialog.open({
+            component: "k-remove-dialog",
+            props: { text: this.$t("field.entries.delete.confirm.all") },
+            on: {
+              submit: () => {
+                this.$api
+                  .get("formblock", {
+                    action: "deleteAll",
+                    page_id: this.value.page,
+                    form_id: this.value.id,
+                  })
+                  .then((t) => {
+                    this.$emit("refresh"), this.$panel.dialog.close();
+                  });
+              },
+            },
+          });
+        },
+      },
+    },
+    f = {};
+  var Y = d(T, E, R, !1, B, null, null, null);
+  function B(t) {
+    for (let e in f) this[e] = f[e];
+  }
+  var L = (function () {
+      return Y.exports;
+    })(),
+    j = function () {
+      var t = this,
+        e = t.$createElement,
+        n = t._self._c || e;
+      return n(
+        "div",
+        { staticClass: "k-field-type-mail-view" },
+        [
+          t.loading
+            ? n("k-box", {
+                attrs: {
+                  theme: "info",
+                  icon: "loader",
+                  text: t.$t("form.block.inbox.loading"),
+                },
+              })
+            : n(
+                "k-grid",
+                {
+                  style: { gap: "var(--spacing-2)" },
+                  attrs: { variant: "fields" },
+                },
+                [
+                  t._l(t.data, function (i) {
+                    return n("k-mail-list", {
+                      key: i.slug,
+                      staticClass: "k-table k-field-type-mail-table",
+                      staticStyle: { "--width": "1/1" },
+                      attrs: {
+                        hideheader: t.hideheader,
+                        value: i,
+                        showuuid: t.isUnique(i),
+                      },
+                      on: { refresh: t.updateList },
+                    });
+                  }),
+                  t.data.length === 0
+                    ? n("k-box", {
+                        staticStyle: { "--width": "1/1" },
+                        attrs: {
+                          theme: "info",
+                          text: t.$t("form.block.inbox.empty"),
+                        },
+                      })
+                    : t._e(),
+                ],
+                2
+              ),
+          n("k-plain-license", { attrs: { prefix: "formblock" } }),
+        ],
+        1
+      );
+    },
+    F = [];
+  const N = {
+      props: {
+        value: { type: String, default: "" },
+        dateformat: { type: String, default: "DD.MM.YYYY HH:mm" },
+        forms: { type: Array, default: () => [] },
+        formData: { type: Object, default: () => {} },
+      },
+      data() {
+        return { data: [], filter: [], loading: !0, hideheader: !1 };
+      },
+      computed: {
+        thispage() {
+          return this.$attrs.endpoints.model
+            .replace("/pages/", "")
+            .replace(/\+/g, "/");
+        },
+      },
+      created() {
+        this.formData.formid
+          ? ((this.filter = [this.formData.formid]), (this.hideheader = !0))
+          : (this.filter = this.forms),
+          this.updateList(),
+          window.panel.events.on("form.update", this.updateList);
+      },
+      destroyed() {
+        window.panel.events.off("form.update", this.updateList);
+      },
+      methods: {
+        send(t, e, n) {
+          var i, a;
+          this.$api
+            .get("formblock", {
+              action: t,
+              page_id: this.thispage,
+              request_id: (i = e == null ? void 0 : e.request) != null ? i : "",
+              form_id: (a = e == null ? void 0 : e.form) != null ? a : "",
+              params: JSON.stringify(e),
+            })
+            .then((l) => {
+              (this.loading = !1), n(l);
+            });
+        },
+        isUnique(t) {
+          return (
+            this.data.filter(
+              (e) =>
+                t.header.page === e.header.page &&
+                t.header.name === e.header.name
+            ).length > 1
+          );
+        },
+        updateList() {
+          let t = this;
+          this.send("requestsArray", { filter: this.filter }, (e) => {
+            this.data = Object.keys(e).map(function (n) {
+              return (
+                (e[n].content = e[n].content.map((i) => {
+                  (i.formid = n),
+                    (i.attachment =
+                      "attachment" in i ? JSON.parse(i.attachment) : !1),
+                    (i.formdata = JSON.parse(i.formdata)),
+                    (i.formfields =
+                      "formfields" in i ? JSON.parse(i.formfields) : !1);
+                  let a = t.$library.dayjs(i.received, "YYYY-MM-DD HH:mm:ss");
+                  return (
+                    (i.info = a.isValid() ? a.format(t.dateformat) : ""),
+                    (i.text = t.getLabel(i)),
+                    (i.image = t.getImage(i)),
+                    (i.buttons = [t.getButton("info", i)]),
+                    (i.options = [
+                      i.read === ""
+                        ? t.getButton("unread", i)
+                        : t.getButton("read", i),
+                      t.getButton("delete", i),
+                    ]),
+                    i
+                  );
+                })),
+                e[n]
+              );
+            });
+          });
+        },
+        setRead(t, e) {
+          this.send(
+            "update",
+            {
+              form: e.formid,
+              request: e.slug,
+              read:
+                t == !1
+                  ? ""
+                  : this.$library.dayjs().format("YYYY-MM-DD HH:mm:ss"),
+            },
+            () => {
+              window.panel.events.emit("form.update"),
+                this.$panel.dialog.close();
             }
-          })
-        };
+          );
+        },
+        getLabel(t) {
+          return t.display
+            ? t.display
+            : this.value
+            ? this.$helper.string.template(this.value, t.formdata)
+            : t.id;
+        },
+        getButton(t, e) {
+          return t === "delete"
+            ? {
+                icon: "trash",
+                text: this.$t("form.block.inbox.delete"),
+                click: () =>
+                  this.send(
+                    "delete",
+                    { form: e.formid, request: e.slug },
+                    () => {
+                      window.panel.events.emit("form.update");
+                    }
+                  ),
+              }
+            : t === "unread"
+            ? {
+                icon: "preview",
+                text: this.$t("form.block.inbox.asread"),
+                click: () => this.setRead(!0, e),
+              }
+            : t === "read"
+            ? {
+                icon: "hidden",
+                text: this.$t("form.block.inbox.asunread"),
+                click: () => this.setRead(!1, e),
+              }
+            : {
+                icon: "info",
+                click: () =>
+                  this.$panel.dialog.open({
+                    component: "k-mail-dialog",
+                    props: {
+                      current: e,
+                      size: "medium",
+                      submitButton: e.read ? {} : this.getButton("unread", e),
+                      cancelButton: e.read ? this.getButton("read", e) : {},
+                    },
+                  }),
+              };
+        },
+        getImage(t) {
+          return t.read
+            ? { icon: "circle", color: "yellow", back: "transparent" }
+            : t.error
+            ? { icon: "cancel", color: "red", back: "transparent" }
+            : { icon: "circle-filled", color: "green", back: "transparent" };
+        },
       },
-      getImage(req) {
-        if (req.read)
-          return {
-            icon: "circle",
-            color: "yellow",
-            back: "transparent"
-          };
-        if (req.error)
-          return {
-            icon: "cancel",
-            color: "red",
-            back: "transparent"
-          };
-        return {
-          icon: "circle-filled",
-          color: "green",
-          back: "transparent"
-        };
-      }
-    }
-  };
-  var _sfc_render$1 = function render() {
-    var _vm = this, _c = _vm._self._c;
-    return _c("div", { staticClass: "k-field-type-mail-view" }, [_vm.loading ? _c("k-box", { attrs: { "theme": "info", "icon": "loader", "text": _vm.$t("form.block.inbox.loading") } }) : _c("k-grid", { style: { gap: "var(--spacing-2)" }, attrs: { "variant": "fields" } }, [_vm._l(_vm.data, function(group) {
-      return _c("k-mail-list", { key: group.slug, staticClass: "k-table k-field-type-mail-table", staticStyle: { "--width": "1/1" }, attrs: { "hideheader": _vm.hideheader, "value": group, "showuuid": _vm.isUnique(group) }, on: { "refresh": _vm.updateList } });
-    }), _vm.data.length === 0 ? _c("k-box", { staticStyle: { "--width": "1/1" }, attrs: { "theme": "info", "text": _vm.$t("form.block.inbox.empty") } }) : _vm._e()], 2), _c("k-plain-license", { attrs: { "prefix": "formblock" } })], 1);
-  };
-  var _sfc_staticRenderFns$1 = [];
-  _sfc_render$1._withStripped = true;
-  var __component__$1 = /* @__PURE__ */ normalizeComponent(
-    _sfc_main$1,
-    _sfc_render$1,
-    _sfc_staticRenderFns$1
-  );
-  __component__$1.options.__file = "/Users/romangsponer/Cloud/_kirby/kdev/site/plugins/kirby-form-block-suite/src/components/fields/MailView.vue";
-  const MailView = __component__$1.exports;
-  const _sfc_main = {
-    props: {
-      prefix: {
-        type: String,
-        default() {
-          return null;
-        }
-      },
-      styling: {
-        type: Object,
-        default() {
-          return {};
-        }
-      }
     },
-    data() {
-      return {
-        license: null
-      };
+    h = {};
+  var A = d(N, j, F, !1, H, null, null, null);
+  function H(t) {
+    for (let e in h) this[e] = h[e];
+  }
+  var I = (function () {
+      return A.exports;
+    })(),
+    J = function () {
+      var t = this,
+        e = t.$createElement,
+        n = t._self._c || e;
+      return t.license !== null
+        ? n(
+            "div",
+            {
+              staticClass: "k-plain-license",
+              style: t.containerStyle,
+              on: { click: t.showDialog },
+            },
+            [
+              n("k-text", {
+                style: t.textStyle,
+                attrs: { size: "tiny", html: t.licenseText },
+              }),
+              n("k-icon", { style: t.iconStyle, attrs: { type: "alert" } }),
+            ],
+            1
+          )
+        : t._e();
     },
-    computed: {
-      licenseText() {
-        if (!this.license) return "";
-        return `<strong>${this.license.title}</strong><br />${this.license.cta}`;
+    U = [],
+    q = "";
+  const V = {
+      props: {
+        prefix: {
+          type: String,
+          default() {
+            return null;
+          },
+        },
+        styling: {
+          type: Object,
+          default() {
+            return {};
+          },
+        },
       },
-      containerStyle() {
-        return this.styling && this.styling.container ? this.styling.container : this.styling;
+      data() {
+        return { license: null };
       },
-      textStyle() {
-        var _a;
-        return ((_a = this.styling) == null ? void 0 : _a.text) ?? {};
+      computed: {
+        licenseText() {
+          return this.license
+            ? `<strong>${this.license.title}</strong><br />${this.license.cta}`
+            : "";
+        },
+        containerStyle() {
+          return this.styling && this.styling.container
+            ? this.styling.container
+            : this.styling;
+        },
+        textStyle() {
+          var t, e;
+          return (e = (t = this.styling) == null ? void 0 : t.text) != null
+            ? e
+            : {};
+        },
+        iconStyle() {
+          var t, e;
+          return (e = (t = this.styling) == null ? void 0 : t.icon) != null
+            ? e
+            : {};
+        },
       },
-      iconStyle() {
-        var _a;
-        return ((_a = this.styling) == null ? void 0 : _a.icon) ?? {};
-      }
+      created() {
+        (this.license =
+          window.panel.translation.data &&
+          window.panel.translation.data["plain.licenses." + this.prefix]
+            ? window.panel.translation.data["plain.licenses." + this.prefix]
+            : null),
+          (window.panel.translation.data["plain.licenses." + this.prefix] =
+            null);
+      },
+      methods: {
+        showDialog() {
+          this.license &&
+            this.license.dialog &&
+            this.$dialog(this.license.dialog);
+        },
+      },
     },
-    created() {
-      this.license = window.panel.translation.data && window.panel.translation.data["plain.licenses." + this.prefix] ? window.panel.translation.data["plain.licenses." + this.prefix] : null;
-      window.panel.translation.data["plain.licenses." + this.prefix] = null;
-    },
-    methods: {
-      showDialog() {
-        if (this.license && this.license.dialog) {
-          this.$dialog(this.license.dialog);
-        }
-      }
-    }
-  };
-  var _sfc_render = function render() {
-    var _vm = this, _c = _vm._self._c;
-    return _vm.license !== null ? _c("div", { staticClass: "k-plain-license", style: _vm.containerStyle, on: { "click": _vm.showDialog } }, [_c("k-text", { style: _vm.textStyle, attrs: { "size": "tiny", "html": _vm.licenseText } }), _c("k-icon", { style: _vm.iconStyle, attrs: { "type": "alert" } })], 1) : _vm._e();
-  };
-  var _sfc_staticRenderFns = [];
-  _sfc_render._withStripped = true;
-  var __component__ = /* @__PURE__ */ normalizeComponent(
-    _sfc_main,
-    _sfc_render,
-    _sfc_staticRenderFns
-  );
-  __component__.options.__file = "/Users/romangsponer/Cloud/_kirby/kdev/site/plugins/kirby-form-block-suite/utils/PlainLicense.vue";
-  const PlainLicense = __component__.exports;
+    p = {};
+  var z = d(V, J, U, !1, P, null, null, null);
+  function P(t) {
+    for (let e in p) this[e] = p[e];
+  }
+  var X = (function () {
+    return z.exports;
+  })();
   window.panel.plugin("plain/formblock", {
-    fields: {
-      mailview: MailView
-    },
-    components: {
-      "k-mail-list": MailList,
-      "k-mail-dialog": MailDialog,
-      "k-plain-license": PlainLicense
-    },
-    blocks: {
-      form: Form
-    }
+    fields: { mailview: I },
+    components: { "k-mail-list": L, "k-mail-dialog": M, "k-plain-license": X },
+    blocks: { form: w },
   });
 })();

--- a/src/components/MailList.vue
+++ b/src/components/MailList.vue
@@ -1,6 +1,18 @@
 <!-- eslint-disable vue/no-v-html -->
 <template>
   <div class="k-mailview-list">
+    <div v-if="hideheader" class="k-mailview-toolbar">
+      <div class="k-mailview-storage-toggle">
+        <label class="k-mailview-storage-label">{{ $t('form.block.inbox.storage') }}</label>
+        <k-toggle-input :value="storageEnabled" @input="toggleStorage" />
+      </div>
+      <k-button-group v-if="value.content.length > 0" class="k-mailview-buttons">
+        <k-button icon="cancel" theme="red" :text="$t('delete.all')" @click="onDelete"></k-button>
+        <k-button icon="download" :link="value.header.download" :text="$t('form.block.inbox.export')"
+          :download="true"></k-button>
+      </k-button-group>
+    </div>
+
     <div v-if="!hideheader" class="k-mailview-list-header">
       <k-box :theme="value.header.state.theme" :icon="isOpen ? 'angle-up' : 'angle-down'" :text="headerText"
         @click.native="toggleOpen()" />
@@ -8,14 +20,10 @@
         :download="true"></k-button>
     </div>
 
-    <k-button-group v-else class="k-mailview-buttons">
-      <k-button icon="cancel" theme="red" :text="$t('delete.all')" @click="onDelete"></k-button>
-      <k-button icon="download" :link="value.header.download" :text="$t('form.block.inbox.export')"
-        :download="true"></k-button>
-
-    </k-button-group>
-
-    <k-items v-if="isOpen || hideheader" :items="items" />
+    <template v-if="isOpen || hideheader">
+      <k-box v-if="value.content.length === 0" theme="info" :text="$t('form.block.inbox.empty')" />
+      <k-items v-else :items="items" />
+    </template>
   </div>
 </template>
 
@@ -32,21 +40,11 @@ export default {
   data() {
     return {
       isOpen: false,
+      storageEnabled: true,
     };
   },
   computed: {
     items() {
-      const a = this.value.content;
-
-      if (a.length === 0) {
-        return [
-          {
-            text: this.$t("form.block.inbox.empty"),
-            theme: "disabled",
-          },
-        ];
-      }
-
       return this.value.content;
     },
     headerText() {
@@ -61,6 +59,7 @@ export default {
       sessionStorage.getItem(
         `plain.form.showOpen.${this.value.page}.${this.value.uuid}`
       ) === "on";
+    this.storageEnabled = this.value.storageEnabled !== false;
   },
   methods: {
     toggleOpen() {
@@ -69,6 +68,18 @@ export default {
         `plain.form.showOpen.${this.value.page}.${this.value.uuid}`,
         this.isOpen ? "on" : "off"
       );
+    },
+    toggleStorage(newState) {
+      this.$api
+        .get("formblock", {
+          action: 'setStorageEnabled',
+          page_id: this.value.page,
+          form_id: this.value.id,
+          params: JSON.stringify({ enabled: newState })
+        })
+        .then(() => {
+          this.storageEnabled = newState;
+        });
     },
     onDelete() {
       this.$panel.dialog.open({
@@ -105,9 +116,27 @@ export default {
 
 }
 
+.k-mailview-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-3);
+}
+
 .k-mailview-buttons {
   display: flex;
-  justify-content: end;
+  align-items: center;
+}
+
+.k-mailview-storage-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.k-mailview-storage-label {
+  font-size: var(--text-sm);
+  white-space: nowrap;
 }
 
 .k-mailview-list-header {

--- a/src/components/blocks/Form.vue
+++ b/src/components/blocks/Form.vue
@@ -18,6 +18,15 @@
       />
 
       <k-box
+        v-else-if="!status.storageEnabled"
+        icon="cancel"
+        style="--width: 2/3"
+        theme="info"
+        :text="$t('form.block.inbox.storage.disabled')"
+        @click.native="open"
+      />
+
+      <k-box
         v-else
         icon="email"
         style="--width: 2/3"


### PR DESCRIPTION
This pull request introduces a feature to enable or disable message storage for forms.
I often encountered the requirement that messages sent via forms not be saved due to data protection regulations. Since this wasn't possible before, I've added a toggle for this feature. 
In the edit view under the “Inbox” tab, there is now a toggle to enable and disable message storage. By default, storage is enabled and the behavior remains the same as before. Using this toggle, future message storage can be disabled on a per-form basis if necessary.


The changes add backend logic to control storage per form, update the frontend to allow toggling storage, and enhance user feedback when storage is disabled. Additionally, new translations are provided for the relevant UI strings.

**Backend: Form Storage Toggle Support**
- Added `setStorageEnabled` and `isStorageEnabled` methods to the `Request` class to allow enabling or disabling storage for individual forms, and updated form creation and file upload logic to respect the storage setting. [[1]](diffhunk://#diff-dc0298cbf07f311515b14868f8e06112f2aa9a3a4a0af290428f0b011d901c5cR237-R273) [[2]](diffhunk://#diff-c380923c92306a8e0cd1507c552739451f8ac7bca3cb3882f64e7700da11a2ccR743-R745) [[3]](diffhunk://#diff-c380923c92306a8e0cd1507c552739451f8ac7bca3cb3882f64e7700da11a2ccL752-R758) [[4]](diffhunk://#diff-dc0298cbf07f311515b14868f8e06112f2aa9a3a4a0af290428f0b011d901c5cL547-R620) [[5]](diffhunk://#diff-dc0298cbf07f311515b14868f8e06112f2aa9a3a4a0af290428f0b011d901c5cR638) [[6]](diffhunk://#diff-dc0298cbf07f311515b14868f8e06112f2aa9a3a4a0af290428f0b011d901c5cR647-R649)

**Frontend: UI for Storage Toggle**
- Updated `MailList.vue` to display a toggle switch for enabling/disabling message storage, and to show an info box if storage is disabled. The toggle updates the backend via an API call. [[1]](diffhunk://#diff-f8431a9e9f81d577871dcce6634cf99f6beebd1225d610744d77417b9d304748R4-R26) [[2]](diffhunk://#diff-f8431a9e9f81d577871dcce6634cf99f6beebd1225d610744d77417b9d304748R43-L49) [[3]](diffhunk://#diff-f8431a9e9f81d577871dcce6634cf99f6beebd1225d610744d77417b9d304748R62) [[4]](diffhunk://#diff-f8431a9e9f81d577871dcce6634cf99f6beebd1225d610744d77417b9d304748R72-R83) [[5]](diffhunk://#diff-7b2eaebd14a480b33c3ab236341cb0eefdb70327e48752e97d87d379c1c0006eR20-R28)

**API and Data Handling**
- Extended the `requestsArray` and `info` methods in `Request.php` to include the `storageEnabled` status in their responses, ensuring the frontend receives up-to-date storage state for each form. [[1]](diffhunk://#diff-dc0298cbf07f311515b14868f8e06112f2aa9a3a4a0af290428f0b011d901c5cL278-R320) [[2]](diffhunk://#diff-dc0298cbf07f311515b14868f8e06112f2aa9a3a4a0af290428f0b011d901c5cR515) [[3]](diffhunk://#diff-dc0298cbf07f311515b14868f8e06112f2aa9a3a4a0af290428f0b011d901c5cR526-R554) [[4]](diffhunk://#diff-dc0298cbf07f311515b14868f8e06112f2aa9a3a4a0af290428f0b011d901c5cR490-L453)

**Styling**
- Added new CSS classes for the toolbar and storage toggle UI elements in `index.css` to improve layout and consistency. [[1]](diffhunk://#diff-337cc548d34c6d80b758ad814ddd793a9ec155eb664e127c1fc4d8c5abd19b8aR33-R50) [[2]](diffhunk://#diff-337cc548d34c6d80b758ad814ddd793a9ec155eb664e127c1fc4d8c5abd19b8aL46) [[3]](diffhunk://#diff-f8431a9e9f81d577871dcce6634cf99f6beebd1225d610744d77417b9d304748R119-R139)

**Internationalization**
- Added new translation strings for storage-related UI in all supported languages. [[1]](diffhunk://#diff-1a490f08504158838befaa816ee8d5c08dff9e694d5a568ce4b0a4398dcc563eR18-R19) [[2]](diffhunk://#diff-521015e818f1c92aaa8776ce306054e2c82f5441b9baf4b3ea5d0ab15be67416L141-R143) [[3]](diffhunk://#diff-849e3fab5f8f13d7147af2a08e45ac75945b75506dae850ca68d942a3c34c142R142-R143) [[4]](diffhunk://#diff-aad75226186c1074810dad93b003f11ce9217c361eb7a809aa309376748d8b83R142-R143) [[5]](diffhunk://#diff-bb127f892e51adad491a70b808c09af4af405c4fcbe9ef504757f88ea4bab994R142-R143) [[6]](diffhunk://#diff-e28b7779ca0f0c09f8e477273cb0c64b5c904cf9c7177cbe25b3e8de0a70a403R142-R143)

@plain-solutions-gmbh Since the changes were significant, please test everything again. Let me know if you notice anything during testing. I'll be happy to fix it.